### PR TITLE
feat: use by-hand-tolerance

### DIFF
--- a/factory/ODDPixelBarrel_geo.cpp
+++ b/factory/ODDPixelBarrel_geo.cpp
@@ -213,13 +213,17 @@ static Ref_t create_element(Detector& oddd, xml_h xml, SensitiveDetector sens) {
     // Place the layer with appropriate Acts::Extension
     // Configure the ACTS extension
     Acts::ActsExtension* layerExtension = new Acts::ActsExtension();
+    layerExtension->addType("sensitive cylinder", "layer");
+    layerExtension->addValue(1., "r_min", "envelope");
+    layerExtension->addValue(5., "r_max", "envelope");   
+    layerExtension->addValue(5., "z_min", "envelope");
+    layerExtension->addValue(5., "z_max", "envelope");     
     // Add the proto layer material
     for (xml_coll_t lmat(x_layer, _Unicode(layer_material)); lmat; ++lmat) {
       xml_comp_t x_layer_material = lmat;
       xmlToProtoSurfaceMaterial(x_layer_material, *layerExtension,
                                 "layer_material");
     }
-    layerExtension->addType("sensitive cylinder", "layer");
     layerElement.addExtension<Acts::ActsExtension>(layerExtension);
 
     PlacedVolume placedLayer = barrelVolume.placeVolume(layerVolume);

--- a/factory/ODDPixelEndcap_geo.cpp
+++ b/factory/ODDPixelEndcap_geo.cpp
@@ -166,6 +166,10 @@ static Ref_t create_element(Detector& oddd, xml_h xml, SensitiveDetector sens) {
     // Configure the ACTS extension
     Acts::ActsExtension* layerExtension = new Acts::ActsExtension();
     layerExtension->addType("sensitive disk", "layer");
+    layerExtension->addValue(10., "r_min", "envelope");
+    layerExtension->addValue(10., "r_max", "envelope");   
+    layerExtension->addValue(10., "z_min", "envelope");
+    layerExtension->addValue(10., "z_max", "envelope");        
     layerElement.addExtension<Acts::ActsExtension>(layerExtension);
     // Add the proto layer material
     for (xml_coll_t lmat(x_layer, _Unicode(layer_material)); lmat; ++lmat) {

--- a/factory/ODDStripBarrel_geo.cpp
+++ b/factory/ODDStripBarrel_geo.cpp
@@ -162,6 +162,10 @@ static Ref_t create_element(Detector& oddd, xml_h xml, SensitiveDetector sens) {
     // Configure the ACTS extension
     Acts::ActsExtension* layerExtension = new Acts::ActsExtension();
     layerExtension->addType("sensitive cylinder", "layer");
+    layerExtension->addValue(10., "r_min", "envelope");
+    layerExtension->addValue(25., "r_max", "envelope");   
+    layerExtension->addValue(10., "z_min", "envelope");
+    layerExtension->addValue(10., "z_max", "envelope");     
     layerElement.addExtension<Acts::ActsExtension>(layerExtension);
     // Add the proto layer material
     for (xml_coll_t lmat(x_layer, _Unicode(layer_material)); lmat; ++lmat) {

--- a/factory/ODDStripEndcap_geo.cpp
+++ b/factory/ODDStripEndcap_geo.cpp
@@ -166,7 +166,12 @@ static Ref_t create_element(Detector& oddd, xml_h xml, SensitiveDetector sens) {
     // Configure the ACTS extension
     Acts::ActsExtension* layerExtension = new Acts::ActsExtension();
     layerExtension->addType("sensitive disk", "layer");
+    layerExtension->addValue(25, "r_min", "envelope");
+    layerExtension->addValue(10, "r_max", "envelope");
+    layerExtension->addValue(10, "z_min", "envelope");
+    layerExtension->addValue(10, "z_max", "envelope");
     layerElement.addExtension<Acts::ActsExtension>(layerExtension);
+
     // Add the proto layer material
     for (xml_coll_t lmat(x_layer, _Unicode(layer_material)); lmat; ++lmat) {
       xml_comp_t x_layer_material = lmat;


### PR DESCRIPTION
This PR changes to use by-hand evelopes rather than the DD4hep volumes, this fixes some navigation problems, and is a first step towards fine-tuning the material description.

![ODD_tX0_preliminary](https://user-images.githubusercontent.com/26623879/114685371-14457300-9d12-11eb-98d3-2b24b3620838.png)
