### PR TITLE
chore: renaming mapping config file

### DIFF
--- a/config/odd-material-mapping.config
+++ b/config/odd-material-mapping.config
@@ -773,7 +773,7 @@
                                     "value": "binPhi"
                                 },
                                 {
-                                    "bins": 25,
+                                    "bins": 50,
                                     "max": 0.0,
                                     "min": 0.0,
                                     "option": "open",
@@ -1214,7 +1214,7 @@
                                     "value": "binPhi"
                                 },
                                 {
-                                    "bins": 25,
+                                    "bins": 50,
                                     "max": 0.0,
                                     "min": 0.0,
                                     "option": "open",
@@ -1896,7 +1896,7 @@
                         "binUtility": {
                             "binningdata": [
                                 {
-                                    "bins": 36,
+                                    "bins": 72,
                                     "max": 3.1415927410125732,
                                     "min": -3.1415927410125732,
                                     "option": "closed",
@@ -1904,7 +1904,7 @@
                                     "value": "binPhi"
                                 },
                                 {
-                                    "bins": 50,
+                                    "bins": 150,
                                     "max": 0.0,
                                     "min": 0.0,
                                     "option": "open",


### PR DESCRIPTION
The material mapping file is renamed to what it actually is.