### PR TITLE
fat: synchronize endcap modules

### DIFF
--- a/xml/OpenDataLongStrips.xml
+++ b/xml/OpenDataLongStrips.xml
@@ -2,36 +2,36 @@
     <!--EndcapN-->
     <detector id="301" name="LongStripEndcapN" type="ODDStripEndcap" readout="LongStripEndcapReadout" vis="invisible">
         <dimensions name="LongStripEndcapShape" rmin="ls_env_rmin" rmax="ls_env_rmax" dz="ls_e_dz" z="ls_e_nz"/>
-        <ring name="Ring0" r="820.*mm" nphi="44" reflect="true" phi0="0." gap="8.*mm" z_offset="15.*mm"> 
+        <ring name="Ring0" r="820.*mm" nphi="48" reflect="true" phi0="0." gap="8.*mm" z_offset="15.*mm"> 
           <module name="LongStripEndcapModuleR0" vis="invisible">
-             <module_component name="Sensor" alpha="0." x1="54.4*mm" x2="66.6*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="2.5*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
-             <module_component name="Board" alpha="0." x1="55.2*mm" x2="67.2*mm" length="80.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="2.25*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
-             <module_component name="Foam" alpha="0." x1="55.2*mm" x2="67.2*mm" length="96.8*mm" thickness="4.*mm" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm" material="CarbonFiber" vis="CarbonFoam" sensitive="false">
+             <module_component name="Sensor" alpha="-0.02" x1="53.2*mm" x2="58.6*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="2.5*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
+             <module_component name="Board" alpha="-0.02" x1="53.8*mm" x2="59.2*mm" length="80.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="2.25*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
+             <module_component name="Foam" alpha="0." x1="54.8*mm" x2="60.2*mm" length="82.8*mm" thickness="4.*mm" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm" material="CarbonFiber" vis="CarbonFoam" sensitive="false">
                <subtraction name="CoolingLine" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm">
                  <tubs name="FoamCutout" rmin="0." rmax="1.6*mm"  z_offset="0.*mm" dz="20.*mm"/>
                </subtraction>
                <tube name="CoolingPipe" rmin="1.4*mm" rmax="1.5*mm" dz="48.5*mm" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm" material="Ti" vis="orange" />
              </module_component>
-             <module_component name="Board" alpha="0.04" x1="55.2*mm" x2="67.2*mm" length="80.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-2.25*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
-             <module_component name="Sensor" alpha="0.04" x1="54.4*mm" x2="66.6*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-2.5*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
+             <module_component name="Board" alpha="0.02" x1="53.2*mm" x2="58.6*mm" length="80.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-2.25*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
+             <module_component name="Sensor" alpha="0.02" x1="53.8*mm" x2="59.2*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-2.5*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
          </module>                   
          <support name="SupportRing0" rmin="720.*mm" rmax="735.*mm" dz="4.*mm" z_offset="0.*mm" material="CarbonFiber" vis="CarbonFiber"/>
          <support name="SupportRing1" rmin="900.*mm" rmax="920.*mm" dz="4.*mm" z_offset="0.*mm" material="CarbonFiber" vis="CarbonFiber"/>
          <cooling_ring rmin="1.4*mm" rmax="1.6*mm" r="922.*mm" gap="22.66*mm" nphi="64" z_offset="0.*mm" material="Ti" vis="orange"/>
         </ring>
     
-        <ring name="Ring1" r="990.*mm" nphi="52" reflect="true" phi0="0." gap="8.*mm" z_offset="-15.*mm"> 
+        <ring name="Ring1" r="990.*mm" nphi="48" reflect="true" phi0="0." gap="8.*mm" z_offset="-15.*mm"> 
           <module name="LongStripEndcapModuleR1" vis="invisible">
-             <module_component name="Sensor" alpha="0." x1="66.6*mm" x2="78*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="2.5*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
-             <module_component name="Board" alpha="0." x1="67.2*mm" x2="78.8*mm" length="80.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="2.25*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
-             <module_component name="Foam" alpha="0." x1="67.2*mm" x2="78.8*mm" length="96.8*mm" thickness="4.*mm" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm" material="CarbonFiber" vis="CarbonFoam" sensitive="false">
+             <module_component name="Sensor" alpha="-0.02" x1="64.6*mm" x2="70.*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="2.5*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
+             <module_component name="Board" alpha="-0.02" x1="65.2*mm" x2="70.6*mm" length="80.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="2.25*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
+             <module_component name="Foam" alpha="0." x1="66.2*mm" x2="71.6*mm" length="82.8*mm" thickness="4.*mm" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm" material="CarbonFiber" vis="CarbonFoam" sensitive="false">
                <subtraction name="CoolingLine" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm">
                  <tubs name="FoamCutout" rmin="0." rmax="1.6*mm"  z_offset="0.*mm" dz="20.*mm"/>
                </subtraction>
                <tube name="CoolingPipe" rmin="1.4*mm" rmax="1.5*mm" dz="48.5*mm" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm" material="Ti" vis="orange" />
              </module_component>
-             <module_component name="Board" alpha="0.04" x1="66.6*mm" x2="78.*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-2.25*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
-             <module_component name="Sensor" alpha="0.04" x1="54.4*mm" x2="78.8*mm" length="80.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-2.5*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
+             <module_component name="Board" alpha="0.02" x1="64.6*mm" x2="70.*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-2.25*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
+             <module_component name="Sensor" alpha="0.02" x1="65.2*mm" x2="70.6*mm" length="80.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-2.5*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
          </module>
          <support name="SupportRing1" rmin="1070.*mm" rmax="1090.*mm" dz="4.*mm" z_offset="0.*mm" material="CarbonFiber" vis="CarbonFiber"/>
           <cooling_ring rmin="1.4*mm" rmax="1.6*mm" r="1092.*mm" gap="23.85*mm" nphi="72" z_offset="0.*mm" material="Ti" vis="orange"/>
@@ -117,17 +117,17 @@
         <dimensions name="LongStripEndcapShape" rmin="ls_env_rmin" rmax="ls_env_rmax" dz="ls_e_dz" z="ls_e_pz"/>
         <ring name="Ring0" r="820.*mm" nphi="44" reflect="true" phi0="0." gap="8.*mm" z_offset="-15.*mm"> 
           <module name="LongStripEndcapModuleR0" vis="invisible">
-             <module_component name="Sensor" alpha="0." x1="54.4*mm" x2="66.6*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="2.5*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
-             <module_component name="Board" alpha="0." x1="55.2*mm" x2="67.2*mm" length="80.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="2.25*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
-             <module_component name="Foam" alpha="0." x1="55.2*mm" x2="67.2*mm" length="96.8*mm" thickness="4.*mm" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm" material="CarbonFiber" vis="CarbonFoam" sensitive="false">
+             <module_component name="Sensor" alpha="-0.02" x1="53.2*mm" x2="58.6*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="2.5*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
+             <module_component name="Board" alpha="-0.02" x1="53.8*mm" x2="59.2*mm" length="80.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="2.25*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
+             <module_component name="Foam" alpha="0." x1="54.8*mm" x2="60.2*mm" length="82.8*mm" thickness="4.*mm" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm" material="CarbonFiber" vis="CarbonFoam" sensitive="false">
                <subtraction name="CoolingLine" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm">
                  <tubs name="FoamCutout" rmin="0." rmax="1.6*mm"  z_offset="0.*mm" dz="20.*mm"/>
                </subtraction>
                <tube name="CoolingPipe" rmin="1.4*mm" rmax="1.5*mm" dz="48.5*mm" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm" material="Ti" vis="orange" />
              </module_component>
-             <module_component name="Board" alpha="0.04" x1="55.2*mm" x2="67.2*mm" length="80.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-2.25*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
-             <module_component name="Sensor" alpha="0.04" x1="54.4*mm" x2="66.6*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-2.5*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
-          </module>                   
+             <module_component name="Board" alpha="0.02" x1="53.2*mm" x2="58.6*mm" length="80.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-2.25*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
+             <module_component name="Sensor" alpha="0.02" x1="53.8*mm" x2="59.2*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-2.5*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
+         </module>                   
           <support name="SupportRing0" rmin="720.*mm" rmax="735.*mm" dz="4.*mm" z_offset="0.*mm" material="CarbonFiber" vis="CarbonFiber"/>
           <support name="SupportRing1" rmin="900.*mm" rmax="920.*mm" dz="4.*mm" z_offset="0.*mm" material="CarbonFiber" vis="CarbonFiber"/>
           <cooling_ring rmin="1.4*mm" rmax="1.6*mm" r="922.*mm" gap="22.66*mm" nphi="64" z_offset="0.*mm" material="Ti" vis="orange"/>
@@ -135,17 +135,17 @@
     
         <ring name="Ring1" r="990.*mm" nphi="52" reflect="true" phi0="0." gap="8.*mm" z_offset="15.*mm"> 
           <module name="LongStripEndcapModuleR1" vis="invisible">
-             <module_component name="Sensor" alpha="0." x1="66.6*mm" x2="78*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="2.5*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
-             <module_component name="Board" alpha="0." x1="67.2*mm" x2="78.8*mm" length="80.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="2.25*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
-             <module_component name="Foam" alpha="0." x1="67.2*mm" x2="78.8*mm" length="96.8*mm" thickness="4.*mm" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm" material="CarbonFiber" vis="CarbonFoam" sensitive="false">
+             <module_component name="Sensor" alpha="-0.02" x1="64.6*mm" x2="70.*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="2.5*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
+             <module_component name="Board" alpha="-0.02" x1="65.2*mm" x2="70.6*mm" length="80.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="2.25*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
+             <module_component name="Foam" alpha="0." x1="66.2*mm" x2="71.6*mm" length="82.8*mm" thickness="4.*mm" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm" material="CarbonFiber" vis="CarbonFoam" sensitive="false">
                <subtraction name="CoolingLine" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm">
                  <tubs name="FoamCutout" rmin="0." rmax="1.6*mm"  z_offset="0.*mm" dz="20.*mm"/>
                </subtraction>
                <tube name="CoolingPipe" rmin="1.4*mm" rmax="1.5*mm" dz="48.5*mm" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm" material="Ti" vis="orange" />
              </module_component>
-             <module_component name="Board" alpha="0.04" x1="66.6*mm" x2="78.*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-2.25*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
-             <module_component name="Sensor" alpha="0.04" x1="54.4*mm" x2="78.8*mm" length="80.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-2.5*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
-          </module> 
+             <module_component name="Board" alpha="0.02" x1="64.6*mm" x2="70.*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-2.25*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
+             <module_component name="Sensor" alpha="0.02" x1="65.2*mm" x2="70.6*mm" length="80.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-2.5*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
+       </module> 
           <support name="SupportRing1" rmin="1070.*mm" rmax="1090.*mm" dz="4.*mm" z_offset="0.*mm" material="CarbonFiber" vis="CarbonFiber"/>
           <cooling_ring rmin="1.4*mm" rmax="1.6*mm" r="1092.*mm" gap="23.85*mm" nphi="72" z_offset="0.*mm" material="Ti" vis="orange"/>
         </ring>

--- a/xml/OpenDataPixels.xml
+++ b/xml/OpenDataPixels.xml
@@ -2,19 +2,19 @@
     <!--EndcapN-->
     <detector id="101" name="PixelEndcapN" type="ODDPixelEndcap" readout="PixelEndcapReadout" vis="invisible">
         <dimensions name="PixelEndcapShape" rmin="pix_env_rmin" rmax="pix_env_rmax" dz="pix_e_dz" z="pix_e_nz"/>
-        <ring id="0" r="76.*mm" nphi="40" z_offset="3.5*mm" phi0="0." gap="0.6*mm" vis="invisible">
+        <ring id="0" r="76.*mm" nphi="24" z_offset="3.5*mm" phi0="0." gap="0.6*mm" vis="invisible">
           <module name="PixelEndcapModule" vis="invisible">
-          <module_component name="Sensor" alpha="0." x1="3.64*mm" x2="9.3*mm" length="36.*mm" thickness="0.125*mm" x_offset="0." y_offset="-0.03" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
-          <module_component name="Board"  alpha="0." x1="3.64*mm" x2="9.3*mm" length="36.*mm" thickness="0.25*mm" x_offset="0." y_offset="0." z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
-          <module_component name="Connector" alpha="0." x1=".6*mm" x2=".6*mm" length="36.*mm" thickness="0.15*mm" x_offset="0.*mm" y_offset="0.3*mm" z_offset="0.*mm" material="Al" vis="red" sensitive="false"/>
+          <module_component name="Sensor" alpha="0." x1="8.5*mm" x2="14.5*mm" length="34.*mm" thickness="0.125*mm" x_offset="0." y_offset="-0.03" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
+          <module_component name="Board"  alpha="0." x1="8.5*mm" x2="14.5*mm" length="34.*mm" thickness="0.25*mm" x_offset="0." y_offset="0." z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
+          <module_component name="Connector" alpha="0." x1="1.6*mm" x2="1.6*mm" length="34.*mm" thickness="0.15*mm" x_offset="0.*mm" y_offset="0.3*mm" z_offset="0.*mm" material="Al" vis="red" sensitive="false"/>
           </module>
         </ring>
 
-        <ring id="1" r="144.*mm" nphi="68" z_offset="-3.5*mm" phi0="0." gap="0.6*mm" vis="invisible">
+        <ring id="1" r="144.*mm" nphi="36" z_offset="-3.5*mm" phi0="0." gap="0.6*mm" vis="invisible">
           <module name="PixelEndcapModule" vis="invisible">
-          <module_component name="Sensor" alpha="0." x1="5.3*mm" x2="8.63*mm" length="36.*mm" thickness="0.125*mm" x_offset="0." y_offset="0.03" z_offset="-5.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
-          <module_component name="Board"  alpha="0." x1="5.3*mm" x2="8.63*mm" length="36.*mm" thickness="0.25*mm" x_offset="0." y_offset="0." z_offset="-5.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
-          <module_component name="Connector" alpha="0." x1=".6*mm" x2=".6*mm" length="36.*mm" thickness="0.15*mm" x_offset="0.*mm" y_offset="-0.3*mm" z_offset="-5.*mm" material="Al" vis="red" sensitive="false"/>
+          <module_component name="Sensor" alpha="0." x1="10.5*mm" x2="16.5*mm" length="34.*mm" thickness="0.125*mm" x_offset="0." y_offset="0.03" z_offset="-5.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
+          <module_component name="Board"  alpha="0." x1="10.5*mm" x2="16.5*mm" length="34.*mm" thickness="0.25*mm" x_offset="0." y_offset="0." z_offset="-5.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
+          <module_component name="Connector" alpha="0." x1="1.6*mm" x2="1.6*mm" length="34.*mm" thickness="0.15*mm" x_offset="0.*mm" y_offset="-0.3*mm" z_offset="-5.*mm" material="Al" vis="red" sensitive="false"/>
           </module>
         </ring>
         <ring_support rmin="36.*mm" rmax="176.*mm" dz="2*mm" material="CarbonFiber" vis="CarbonFiber"/>
@@ -109,18 +109,18 @@
     <!--EndcapP-->
     <detector id="102" name="PixelEndcapP" type="ODDPixelEndcap" readout="PixelEndcapReadout" vis="invisible">
         <dimensions name="PixelEndcapShape" rmin="pix_env_rmin" rmax="pix_env_rmax" dz="pix_e_dz" z="pix_e_pz"/>
-        <ring id="0" r="76.*mm" nphi="40" z_offset="-3.5*mm" phi0="0." gap="0.6*mm" vis="invisible">
+        <ring id="0" r="76.*mm" nphi="24" z_offset="-3.5*mm" phi0="0." gap="0.6*mm" vis="invisible">
           <module name="PixelEndcapModule" vis="invisible">
-          <module_component name="Sensor" alpha="0." x1="3.64*mm" x2="9.3*mm" length="36.*mm" thickness="0.125*mm" x_offset="0." y_offset="0.03" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
-          <module_component name="Board"  alpha="0." x1="3.64*mm" x2="9.3*mm" length="36.*mm" thickness="0.25*mm" x_offset="0." y_offset="0." z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
-          <module_component name="Connector" alpha="0." x1=".6*mm" x2=".6*mm" length="36.*mm" thickness="0.15*mm" x_offset="0.*mm" y_offset="-0.3*mm" z_offset="0.*mm" material="Al" vis="red" sensitive="false"/>
+          <module_component name="Sensor" alpha="0." x1="8.5*mm" x2="14.5*mm" length="34.*mm" thickness="0.125*mm" x_offset="0." y_offset="-0.03" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
+          <module_component name="Board"  alpha="0." x1="8.5*mm" x2="14.5*mm" length="34.*mm" thickness="0.25*mm" x_offset="0." y_offset="0." z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
+          <module_component name="Connector" alpha="0." x1="1.6*mm" x2="1.6*mm" length="34.*mm" thickness="0.15*mm" x_offset="0.*mm" y_offset="0.3*mm" z_offset="0.*mm" material="Al" vis="red" sensitive="false"/>
           </module>
         </ring>
-        <ring id="1" r="144.*mm" nphi="68" z_offset="3.5*mm" phi0="0." gap="0.6*mm" vis="invisible">
+        <ring id="1" r="144.*mm" nphi="36" z_offset="3.5*mm" phi0="0." gap="0.6*mm" vis="invisible">
           <module name="PixelEndcapModule" vis="invisible">
-          <module_component name="Sensor" alpha="0." x1="5.3*mm" x2="8.63*mm" length="36.*mm" thickness="0.125*mm" x_offset="0." y_offset="-0.03" z_offset="-5.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
-          <module_component name="Board"  alpha="0." x1="5.3*mm" x2="8.63*mm" length="36.*mm" thickness="0.25*mm" x_offset="0." y_offset="0." z_offset="-5.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
-          <module_component name="Connector" alpha="0." x1=".6*mm" x2=".6*mm" length="36.*mm" thickness="0.15*mm" x_offset="0.*mm" y_offset="0.3*mm" z_offset="-5.*mm" material="Al" vis="red" sensitive="false"/>
+          <module_component name="Sensor" alpha="0." x1="10.5*mm" x2="16.5*mm" length="34.*mm" thickness="0.125*mm" x_offset="0." y_offset="0.03" z_offset="-5.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
+          <module_component name="Board"  alpha="0." x1="10.5*mm" x2="16.5*mm" length="34.*mm" thickness="0.25*mm" x_offset="0." y_offset="0." z_offset="-5.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
+          <module_component name="Connector" alpha="0." x1="1.6*mm" x2="1.6*mm" length="34.*mm" thickness="0.15*mm" x_offset="0.*mm" y_offset="-0.3*mm" z_offset="-5.*mm" material="Al" vis="red" sensitive="false"/>
           </module>
         </ring>
         <ring_support rmin="36.*mm" rmax="176.*mm" dz="2*mm" material="CarbonFiber" vis="CarbonFiber"/> 

--- a/xml/OpenDataShortStrips.xml
+++ b/xml/OpenDataShortStrips.xml
@@ -4,8 +4,8 @@
         <dimensions name="ShortStripEndcapShape" rmin="ss_env_rmin" rmax="ss_env_rmax" dz="ss_e_dz" z="ss_e_nz"/>
         <ring name="Ring0" r="318*mm" nphi="42" reflect="true" phi0="0." gap="2.5*mm" z_offset="5.*mm"> 
           <module name="ShortStripEndcapModuleR0" vis="invisible">
-            <module_component name="Sensor" alpha="0." x1="18.4*mm" x2="30.2*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
-            <module_component name="Board" alpha="0." x1="19.2*mm" x2="31.*mm" length="78.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-0.375*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
+            <module_component name="Sensor" alpha="0." x1="18.4*mm" x2="32.2*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
+            <module_component name="Board" alpha="0." x1="19.2*mm" x2="33.*mm" length="78.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-0.375*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
             <module_component name="Connector" alpha="0." x1="10.2*mm" x2="15.*mm" length="44.8*mm" thickness="0.2*mm" x_offset="0.*mm" y_offset="-0.7*mm" z_offset="0.*mm" material="Al" vis="red" sensitive="false"/>
           </module>
           <support name="SupportRing0" rmin="220.*mm" rmax="270.*mm" dz="2.*mm" z_offset="0.*mm" material="CarbonFiber" vis="CarbonFiber"/>
@@ -14,17 +14,17 @@
           <support name="SupportRing1" rmin="370.*mm" rmax="430.*mm" dz="2.*mm" z_offset="0.*mm" material="CarbonFiber" vis="CarbonFiber"/>
           <cooling_ring rmin="1.4*mm" rmax="1.6*mm" r="432.*mm" gap="21.3*mm" nphi="32" z_offset="0.*mm" material="Ti" vis="orange"/>
         </ring>
-        <ring name="Ring1" r="470*mm" nphi="50" reflect="true" phi0="0." gap="2.5*mm" z_offset="-5.*mm">
+        <ring name="Ring1" r="470*mm" nphi="42" reflect="true" phi0="0.0748*rad" gap="2.5*mm" z_offset="-5.*mm">
           <module name="ShortStripEndcapModuleR1" vis="invisible">
-            <module_component name="Sensor" alpha="0." x1="25.2*mm" x2="36.2*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
-            <module_component name="Board" alpha="0." x1="26.0*mm" x2="37.*mm" length="78.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-0.475*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
+            <module_component name="Sensor" alpha="0." x1="30.2*mm" x2="44.0*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
+            <module_component name="Board" alpha="0." x1="31.0*mm" x2="44.8*mm" length="78.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-0.475*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
             <module_component name="Connector" alpha="0." x1="15.2*mm" x2="22.*mm" length="44.8*mm" thickness="0.2*mm" x_offset="0.*mm" y_offset="-0.7*mm" z_offset="0.*mm" material="Al" vis="red" sensitive="false"/>
           </module>
         </ring>
-        <ring name="Ring2" r="622*mm" nphi="60" reflect="true" phi0="0." gap="2.5*mm" z_offset="5.*mm">
+        <ring name="Ring2" r="622*mm" nphi="42" reflect="true" phi0="0." gap="2.5*mm" z_offset="5.*mm">
           <module name="ShortStripEndcapModuleR2" vis="invisible">
-            <module_component name="Sensor" alpha="0." x1="32.2*mm" x2="38.*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
-            <module_component name="Board" alpha="0." x1="33.0*mm" x2="38.8*mm" length="78.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-0.375*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
+            <module_component name="Sensor" alpha="0." x1="40.8*mm" x2="56.4*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
+            <module_component name="Board" alpha="0." x1="41.6*mm" x2="57.2*mm" length="78.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-0.375*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
             <module_component name="Connector" alpha="0." x1="22.2*mm" x2="28.*mm" length="44.8*mm" thickness="0.2*mm" x_offset="0.*mm" y_offset="-0.75*mm" z_offset="0.*mm" material="Al" vis="red" sensitive="false"/>
           </module>
           <cooling_ring rmin="1.4*mm" rmax="1.6*mm" r="504.*mm" gap="19.5*mm" nphi="42" z_offset="0.*mm" material="Ti" vis="orange"/>
@@ -113,8 +113,8 @@
         <dimensions name="ShortStripEndcapShape" rmin="ss_env_rmin" rmax="ss_env_rmax" dz="ss_e_dz" z="ss_e_pz"/>
         <ring name="Ring0" r="318*mm" nphi="42" reflect="true" phi0="0." gap="2.5*mm" z_offset="-5.*mm"> 
           <module name="ShortStripEndcapModuleR0" vis="invisible">
-            <module_component name="Sensor" alpha="0." x1="18.4*mm" x2="30.2*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
-            <module_component name="Board" alpha="0." x1="19.2*mm" x2="31.*mm" length="78.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-0.275*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
+            <module_component name="Sensor" alpha="0." x1="18.4*mm" x2="32.2*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
+            <module_component name="Board" alpha="0." x1="19.2*mm" x2="33.*mm" length="78.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-0.275*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
             <module_component name="Connector" alpha="0." x1="10.2*mm" x2="15.*mm" length="44.8*mm" thickness="0.2*mm" x_offset="0.*mm" y_offset="-0.7*mm" z_offset="0.*mm" material="Al" vis="red" sensitive="false"/>
           </module>
           <support name="SupportRing0" rmin="220.*mm" rmax="270.*mm" dz="2.1*mm" z_offset="0.*mm" material="CarbonFiber" vis="CarbonFiber"/>
@@ -123,17 +123,17 @@
           <support name="SupportRing1" rmin="370.*mm" rmax="430.*mm" dz="2.*mm" z_offset="0.*mm" material="CarbonFiber" vis="CarbonFiber"/>
           <cooling_ring rmin="1.4*mm" rmax="1.6*mm" r="432.*mm" gap="21.3*mm" nphi="32" z_offset="0.*mm" material="Ti" vis="orange"/>
         </ring>
-        <ring name="Ring1" r="470*mm" nphi="50" reflect="true" phi0="0." gap="2.5*mm" z_offset="+5.*mm">
+        <ring name="Ring1" r="470*mm" nphi="42" reflect="true" phi0="0.0748*rad" gap="2.5*mm" z_offset="+5.*mm">
           <module name="ShortStripEndcapModuleR1" vis="invisible">
-            <module_component name="Sensor" alpha="0." x1="25.2*mm" x2="36.2*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
-            <module_component name="Board" alpha="0." x1="26.0*mm" x2="37.*mm" length="78.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-0.475*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
+            <module_component name="Sensor" alpha="0." x1="30.2*mm" x2="44.*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
+            <module_component name="Board" alpha="0." x1="31.0*mm" x2="44.8*mm" length="78.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-0.475*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
             <module_component name="Connector" alpha="0." x1="15.2*mm" x2="22.*mm" length="44.8*mm" thickness="0.2*mm" x_offset="0.*mm" y_offset="-0.7*mm" z_offset="0.*mm" material="Al" vis="red" sensitive="false"/>
           </module>
         </ring>
-        <ring name="Ring2" r="622*mm" nphi="60" reflect="true" phi0="0." gap="2.5*mm" z_offset="-5.*mm">
+        <ring name="Ring2" r="622*mm" nphi="42" reflect="true" phi0="0." gap="2.5*mm" z_offset="-5.*mm">
           <module name="ShortStripEndcapModuleR2" vis="invisible">
-            <module_component name="Sensor" alpha="0." x1="32.2*mm" x2="38.*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
-            <module_component name="Board" alpha="0." x1="33.0*mm" x2="38.8*mm" length="78.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-0.375*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
+            <module_component name="Sensor" alpha="0." x1="40.8*mm" x2="56.4*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
+            <module_component name="Board" alpha="0." x1="41.4*mm" x2="57.2*mm" length="78.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-0.375*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
             <module_component name="Connector" alpha="0." x1="22.2*mm" x2="28.*mm" length="44.8*mm" thickness="0.2*mm" x_offset="0.*mm" y_offset="-0.75*mm" z_offset="0.*mm" material="Al" vis="red" sensitive="false"/>
           </module>
           <cooling_ring rmin="1.4*mm" rmax="1.6*mm" r="504.*mm" gap="19.5*mm" nphi="42" z_offset="0.*mm" material="Ti" vis="orange"/>


### PR DESCRIPTION
This PR synchronises the number of modules on the ODD to make the easily order able in surface grids.