### PR TITLE
feat: adding bfield and material map as lfs files

### DIFF
--- a/data/.gitattributes
+++ b/data/.gitattributes
@@ -1,0 +1,2 @@
+odd-bfield.root filter=lfs diff=lfs merge=lfs -text
+odd-material-map.root filter=lfs diff=lfs merge=lfs -text

--- a/data/odd-bfield.root
+++ b/data/odd-bfield.root
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5be8bf620f7cb26d7072278f6d6838f8e720eb4dab49ce38f644eb066d0af1df
+size 49909458

--- a/data/odd-material-map.root
+++ b/data/odd-material-map.root
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e75afcc8100ebc4e4bc373df4e25a02bb0d65312b4179bbb671c6f4968d10e0
+size 8625803


### PR DESCRIPTION
This PR adds two files tracked by `git-lfs` in a new `data` directory:

```shell
data/odd-bfield.root
data/odd-material-map.root
```
