### PR TITLE
feat: add data lfs

### DIFF
--- a/config/odd-digi-smearing-config.json
+++ b/config/odd-digi-smearing-config.json
@@ -10,7 +10,8 @@
           "value" : {
             "smearing" : [
               {"index" : 0, "mean" : 0.0, "stddev" : 0.015, "type" : "Gauss"},
-              {"index" : 1, "mean" : 0.0, "stddev" : 0.015, "type" : "Gauss"}
+              {"index" : 1, "mean" : 0.0, "stddev" : 0.015, "type" : "Gauss"},
+              {"index" : 5, "mean" : 0.0, "stddev" : 25, "type" : "Gauss"}
             ]
           }
         },
@@ -19,7 +20,8 @@
           "value" : {
             "smearing" : [
               {"index" : 0, "mean" : 0.0, "stddev" : 0.015, "type" : "Gauss"},
-              {"index" : 1, "mean" : 0.0, "stddev" : 0.015, "type" : "Gauss"}
+              {"index" : 1, "mean" : 0.0, "stddev" : 0.015, "type" : "Gauss"},
+              {"index" : 5, "mean" : 0.0, "stddev" : 25, "type" : "Gauss"}
             ]
           }
         },
@@ -28,7 +30,8 @@
           "value" : {
             "smearing" : [
               {"index" : 0, "mean" : 0.0, "stddev" : 0.015, "type" : "Gauss"},
-              {"index" : 1, "mean" : 0.0, "stddev" : 0.015, "type" : "Gauss"}
+              {"index" : 1, "mean" : 0.0, "stddev" : 0.015, "type" : "Gauss"},
+              {"index" : 5, "mean" : 0.0, "stddev" : 25, "type" : "Gauss"}
             ]
           }
         },

--- a/data/.gitattributes
+++ b/data/.gitattributes
@@ -1,0 +1,1 @@
+odd-material-maps.root filter=lfs diff=lfs merge=lfs -text

--- a/data/odd-material-maps.root
+++ b/data/odd-material-maps.root
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b41d4f50f159cf79eeacd31494cdb634c72ed8b6840d73948a8bf0011a2e15a
+size 8928285

--- a/xml/OpenDataLongStrips.xml
+++ b/xml/OpenDataLongStrips.xml
@@ -40,23 +40,23 @@
            <surface_binning nr="2" nphi="48"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
-        <layer id="1" name="LongStripEndcapN2" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="-1600.*mm" vis="invisible">
+        <layer id="1" name="LongStripEndcapN1" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="-1600.*mm" vis="invisible">
            <surface_binning nr="2" nphi="48"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
-        <layer id="2" name="LongStripEndcapN3" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="-1900.*mm" vis="invisible">
+        <layer id="2" name="LongStripEndcapN2" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="-1900.*mm" vis="invisible">
            <surface_binning nr="2" nphi="48"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
-        <layer id="2" name="LongStripEndcapN4" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="-2250.*mm" vis="invisible">
+        <layer id="3" name="LongStripEndcapN3" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="-2250.*mm" vis="invisible">
            <surface_binning nr="2" nphi="48"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
-        <layer id="3" name="LongStripEndcapN5" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="-2600.*mm" vis="invisible">
+        <layer id="4" name="LongStripEndcapN4" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="-2600.*mm" vis="invisible">
            <surface_binning nr="2" nphi="48"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
-        <layer id="4" name="LongStripEndcapN6" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="-3000.*mm" vis="invisible">
+        <layer id="5" name="LongStripEndcapN5" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="-3000.*mm" vis="invisible">
            <surface_binning nr="2" nphi="48"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
@@ -163,19 +163,19 @@
            <surface_binning nr="2" nphi="48"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
-        <layer id="2" name="LongStripEndcapP3" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="1900.*mm" vis="invisible">
+        <layer id="2" name="LongStripEndcapP2" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="1900.*mm" vis="invisible">
            <surface_binning nr="2" nphi="48"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
-        <layer id="2" name="LongStripEndcapP4" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="2250.*mm" vis="invisible">
+        <layer id="3" name="LongStripEndcapP3" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="2250.*mm" vis="invisible">
            <surface_binning nr="2" nphi="48"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
-        <layer id="3" name="LongStripEndcapP5" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="2600.*mm" vis="invisible">
+        <layer id="4" name="LongStripEndcapP4" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="2600.*mm" vis="invisible">
            <surface_binning nr="2" nphi="48"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
-        <layer id="4" name="LongStripEndcapP6" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="3000.*mm" vis="invisible">
+        <layer id="5" name="LongStripEndcapP5" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="3000.*mm" vis="invisible">
            <surface_binning nr="2" nphi="48"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>

--- a/xml/OpenDataShortStrips.xml
+++ b/xml/OpenDataShortStrips.xml
@@ -37,23 +37,23 @@
           <surface_binning nr="3" nphi="42"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
-        <layer id="1" name="ShortStripEndcapN2" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="-1550.*mm" vis="invisible">
+        <layer id="1" name="ShortStripEndcapN1" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="-1550.*mm" vis="invisible">
           <surface_binning nr="3" nphi="42"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
-        <layer id="2" name="ShortStripEndcapN3" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="-1850.*mm" vis="invisible">
+        <layer id="2" name="ShortStripEndcapN2" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="-1850.*mm" vis="invisible">
           <surface_binning nr="3" nphi="42"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
-        <layer id="3" name="ShortStripEndcapN4" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="-2200.*mm" vis="invisible">
+        <layer id="3" name="ShortStripEndcapN3" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="-2200.*mm" vis="invisible">
           <surface_binning nr="3" nphi="42"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
-        <layer id="4" name="ShortStripEndcapN5" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="-2550.*mm" vis="invisible">
+        <layer id="4" name="ShortStripEndcapN4" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="-2550.*mm" vis="invisible">
           <surface_binning nr="3" nphi="42"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
-        <layer id="5" name="ShortStripEndcapN6" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="-2950.*mm" vis="invisible">
+        <layer id="5" name="ShortStripEndcapN5" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="-2950.*mm" vis="invisible">
           <surface_binning nr="3" nphi="42"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
@@ -152,23 +152,23 @@
           <surface_binning nr="3" nphi="42"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
-        <layer id="1" name="ShortStripEndcapP2" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="1550.*mm" vis="invisible">
+        <layer id="1" name="ShortStripEndcapP1" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="1550.*mm" vis="invisible">
           <surface_binning nr="3" nphi="42"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
-        <layer id="2" name="ShortStripEndcapP3" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="1850.*mm" vis="invisible">
+        <layer id="2" name="ShortStripEndcapP2" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="1850.*mm" vis="invisible">
           <surface_binning nr="3" nphi="42"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
-        <layer id="2" name="ShortStripEndcapP4" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="2200.*mm" vis="invisible">
+        <layer id="3" name="ShortStripEndcapP3" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="2200.*mm" vis="invisible">
           <surface_binning nr="3" nphi="42"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
-        <layer id="3" name="ShortStripEndcapP5" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="2550.*mm" vis="invisible">
+        <layer id="4" name="ShortStripEndcapP4" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="2550.*mm" vis="invisible">
           <surface_binning nr="3" nphi="42"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
-        <layer id="4" name="ShortStripEndcapP6" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="2950.*mm" vis="invisible">
+        <layer id="5" name="ShortStripEndcapP5" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="2950.*mm" vis="invisible">
           <surface_binning nr="3" nphi="42"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>


### PR DESCRIPTION
This updates the smearing config file and adds a data directory in which the files are tracked with `git lfs`.

Thie PR adds:
  * `odd-material-maps.root`