### PR TITLE
feat: adding bfield lfs file

### DIFF
--- a/data/.gitattributes
+++ b/data/.gitattributes
@@ -1,1 +1,2 @@
 odd-material-maps.root filter=lfs diff=lfs merge=lfs -text
+odd-bfield.root filter=lfs diff=lfs merge=lfs -text

--- a/data/odd-bfield.root
+++ b/data/odd-bfield.root
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5be8bf620f7cb26d7072278f6d6838f8e720eb4dab49ce38f644eb066d0af1df
+size 49909458


### PR DESCRIPTION
This PR adds a bfield file tracked with `git lfs`.