### PR TITLE
feat: update material maps

### DIFF
--- a/data/odd-material-maps.root
+++ b/data/odd-material-maps.root
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1b41d4f50f159cf79eeacd31494cdb634c72ed8b6840d73948a8bf0011a2e15a
-size 8928285
+oid sha256:a92b709bb0442bda932dc86a91509df4e5dec4e39b65ce9a004a9fccc2970b01
+size 8588904


### PR DESCRIPTION
This PR synchronises the `XML` and provided material map:

(a) before:

![Screenshot 2021-08-30 at 14 39 31](https://user-images.githubusercontent.com/26623879/131347007-5fdbc51a-8bdc-4af2-b734-482cf26b5f80.png)

(b) with this PR:

![Screenshot 2021-08-30 at 15 27 49](https://user-images.githubusercontent.com/26623879/131346985-3cddee8b-07c8-41d9-bcc7-9c357f80406a.png)
